### PR TITLE
Hide tutorials marked as classroom from visitors

### DIFF
--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,11 +1,22 @@
 class WelcomeController < ApplicationController
   def index
-    @tutorials = if params[:tag]
-                   Tutorial
-                     .tagged_with(params[:tag])
-                     .paginate(page: params[:page], per_page: 5)
-                 else
-                   Tutorial.all.paginate(page: params[:page], per_page: 5)
-                 end
+    if current_user
+      @tutorials = if params[:tag]
+                      Tutorial
+                      .tagged_with(params[:tag])
+                      .paginate(page: params[:page], per_page: 5)
+                    else
+                      Tutorial.all.paginate(page: params[:page], per_page: 5)
+                    end
+    else
+      @tutorials = if params[:tag]
+                      Tutorial
+                      .no_classroom
+                      .tagged_with(params[:tag])
+                      .paginate(page: params[:page], per_page: 5)
+                    else
+                      Tutorial.no_classroom.paginate(page: params[:page], per_page: 5)
+                    end
+    end
   end
 end

--- a/app/models/tutorial.rb
+++ b/app/models/tutorial.rb
@@ -2,4 +2,8 @@ class Tutorial < ApplicationRecord
   has_many :videos, -> { order(position: :ASC) }
   acts_as_taggable_on :tags, :tag_list
   accepts_nested_attributes_for :videos
+
+  def self.no_classroom
+    where(classroom: false)
+  end
 end

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -2,7 +2,7 @@
   <main>
 <h4>Register</h4>
   <section>
-    <%= form_for @new do |form| %>
+    <%= form_for @user do |form| %>
       <div >
         <%= form.label :email %>
         <%= form.email_field :email, class: "block col-12 field" %>

--- a/spec/features/user/user_can_see_tutorials_marked_as_classroom_content_spec.rb
+++ b/spec/features/user/user_can_see_tutorials_marked_as_classroom_content_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe 'a user' do
+  it 'can see videos marked as classroom content on homepage' do
+    user = create(:user)
+
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(user)
+
+    classroom_tutorial = create(:tutorial, title: 'This Video is for Logged In Users Only', classroom: true)
+    tutorial = create(:tutorial, title: 'This tutorial can be viewed by Visitors')
+
+    visit '/'
+
+    expect(page).to have_css('.tutorial', count: 2)
+
+    expect(page).to have_content(classroom_tutorial.title)
+    expect(page).to have_content(classroom_tutorial.description)
+
+    expect(page).to have_content(tutorial.title)
+    expect(page).to have_content(tutorial.description)
+  end
+end

--- a/spec/features/visitors/visitor_cannot_see_tutorials_marked_as_classroom_content_spec.rb
+++ b/spec/features/visitors/visitor_cannot_see_tutorials_marked_as_classroom_content_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+describe 'a visitor' do
+  it 'cannot see videos that are marked as classroom' do
+    classroom_tutorial = create(:tutorial, title: 'This Video is for Logged In Users Only', classroom: true)
+    tutorial = create(:tutorial, title: 'This tutorial can be viewed by Visitors')
+
+    visit '/'
+
+    expect(page).to have_css('.tutorial', count: 1)
+
+    expect(page).to_not have_content(classroom_tutorial.title)
+    expect(page).to_not have_content(classroom_tutorial.description)
+
+    expect(page).to have_content(tutorial.title)
+    expect(page).to have_content(tutorial.description)
+  end
+end

--- a/spec/models/tutorial_spec.rb
+++ b/spec/models/tutorial_spec.rb
@@ -1,4 +1,18 @@
 require 'rails_helper'
 
 RSpec.describe Tutorial, type: :model do
+  describe "class methods" do
+    it '.no_classroom' do
+
+      create_list(:tutorial, 3,title: 'This Video is for Logged In Users Only', classroom: true)
+      non_classroom_tutorials = create_list(:tutorial, 3, title: 'This tutorial can be viewed by Visitors')
+
+      expect(Tutorial.no_classroom.count).to eq(3)
+
+      Tutorial.no_classroom.each do |tutorial|
+        expect(tutorial.classroom).to eq(false)
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
- Add class method `no_classroom` to Tutorial model to only return records with attribute `classroom: false`
- Tested visitor and authenticated user visiting homepage and working as intended
- All tests currently passing